### PR TITLE
Fix custom locations not being selected for roads

### DIFF
--- a/ProceduralRoads/Src/Roads/RoadNetworkGenerator.cs
+++ b/ProceduralRoads/Src/Roads/RoadNetworkGenerator.cs
@@ -74,6 +74,7 @@ public static class RoadNetworkGenerator
     };
     
     private const int DefaultPriority = 20;
+    private const int CustomLocationPriority = 80;
     private const int MinLocationsPerIsland = 2;
     private const int MaxLocationsPerIsland = 12;
     private const float AreaPerLocation = 2_000_000f;
@@ -434,7 +435,13 @@ public static class RoadNetworkGenerator
 
     private static int GetLocationPriority(string locationName)
     {
-        return LocationPriorities.TryGetValue(locationName, out int priority) ? priority : DefaultPriority;
+        if (LocationPriorities.TryGetValue(locationName, out int priority))
+            return priority;
+
+        if (RegisteredLocationNames.Contains(locationName))
+            return CustomLocationPriority;
+
+        return DefaultPriority;
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Custom locations registered via config or API were given `DefaultPriority` (20), the lowest tier, causing them to always be cut during island location selection in favor of built-in locations
- Added `CustomLocationPriority` (80) matching dungeon-tier priority so custom locations actually compete for road connections

## Test plan
- [x] Verified with 21 MWL_AIO locations in CustomLocations config
- [x] Confirmed MWL locations now appear in selected candidates and get roads generated (e.g. `MWL_ForestTower3 -> MWL_ForestRuin1`, `MWL_FulingTemple1 -> MWL_FulingVillage1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)