### PR TITLE
Expose MaxLocationsPerIsland as a config option

### DIFF
--- a/ProceduralRoads/Src/Plugin.cs
+++ b/ProceduralRoads/Src/Plugin.cs
@@ -46,6 +46,7 @@ namespace ProceduralRoads
         public static ConfigEntry<string> CustomLocations = null!;
         public static ConfigEntry<int> IslandRoadPercentage = null!;
         public static ConfigEntry<int> PathfindingMaxIterations = null!;
+        public static ConfigEntry<int> MaxLocationsPerIsland = null!;
 
         public void Awake()
         {
@@ -70,6 +71,11 @@ namespace ProceduralRoads
                     "Higher values will generate more roads but increase generation time. " +
                     "Lower values will speed up generation time but cause less roads to generate.",
                     new AcceptableValueRange<int>(1000, 100000)));
+
+            MaxLocationsPerIsland = Config.Bind("Roads", "MaxLocationsPerIsland", 12,
+                new ConfigDescription("Maximum number of locations that can be connected by roads on a single island. " +
+                    "Higher values allow more roads on large islands.",
+                    new AcceptableValueRange<int>(2, 30)));
 
             CustomLocations = Config.Bind("Locations", "CustomLocations", "",
                 "Comma-separated list of location names to include in road generation. " +
@@ -118,6 +124,7 @@ namespace ProceduralRoads
         {
             RoadNetworkGenerator.RoadWidth = RoadWidth.Value;
             RoadNetworkGenerator.IslandRoadPercentage = IslandRoadPercentage.Value;
+            RoadNetworkGenerator.MaxLocationsPerIsland = MaxLocationsPerIsland.Value;
             RoadPathfinder.MaxIterations = PathfindingMaxIterations.Value;
             // CustomLocations is parsed at generation time to preserve API registrations
         }

--- a/ProceduralRoads/Src/Roads/RoadNetworkGenerator.cs
+++ b/ProceduralRoads/Src/Roads/RoadNetworkGenerator.cs
@@ -76,7 +76,7 @@ public static class RoadNetworkGenerator
     private const int DefaultPriority = 20;
     private const int CustomLocationPriority = 80;
     private const int MinLocationsPerIsland = 2;
-    private const int MaxLocationsPerIsland = 12;
+    public static int MaxLocationsPerIsland = 12;
     private const float AreaPerLocation = 2_000_000f;
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Adds a new `MaxLocationsPerIsland` config entry under the "Roads" section, allowing users to control the maximum number of locations connected by roads on a single island (range: 2–30, default: 12)
- Previously this was a hardcoded constant — now it can be tuned for larger islands or custom world setups

## Test plan
- [ ] Verify the new config entry appears in the config file with the correct default value (12)
- [ ] Test with values at the boundaries (2 and 30) to confirm road generation behaves correctly
- [ ] Confirm existing saves/configs without the setting use the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)