### PR TITLE
fix: promote custom location registration log to Info

### DIFF
--- a/ProceduralRoads/Src/Roads/RoadNetworkGenerator.cs
+++ b/ProceduralRoads/Src/Roads/RoadNetworkGenerator.cs
@@ -98,7 +98,7 @@ public static class RoadNetworkGenerator
         string trimmed = locationName.Trim();
         if (RegisteredLocationNames.Add(trimmed))
         {
-            Log.LogDebug($"Registered location for roads: {trimmed}");
+            Log.LogInfo($"Registered location for roads: {trimmed}");
         }
     }
 


### PR DESCRIPTION
## Summary
- Changes `LogDebug` to `LogInfo` for the custom location registration message in `RoadNetworkGenerator`, so mod authors can confirm their locations are registered at the default log level.

## Test plan
- [ ] Verify the log line appears in BepInEx output at default log level when a custom location is registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)