### PR TITLE
Fix PTB ZoneSystem zone IDs

### DIFF
--- a/ProceduralRoads/Src/Patches/ZoneSystem_Patch.cs
+++ b/ProceduralRoads/Src/Patches/ZoneSystem_Patch.cs
@@ -24,7 +24,7 @@ public static class ZoneSystem_Patch
     public static class ZoneSystem_PlaceVegetation_Patch
     {
         [HarmonyPrefix]
-        public static void Prefix(Vector2i zoneID, List<ZoneSystem.ClearArea> clearAreas)
+        public static void Prefix(Vector2s zoneID, List<ZoneSystem.ClearArea> clearAreas)
         {
             if (!RoadNetworkGenerator.RoadsGenerated)
                 return;
@@ -38,7 +38,7 @@ public static class ZoneSystem_Patch
     public static class ZoneSystem_SpawnZone_Patch
     {
         [HarmonyPostfix]
-        public static void Postfix(ZoneSystem __instance, Vector2i zoneID, ZoneSystem.SpawnMode mode, ref bool __result)
+        public static void Postfix(ZoneSystem __instance, Vector2s zoneID, ZoneSystem.SpawnMode mode, ref bool __result)
         {
             if (mode == ZoneSystem.SpawnMode.Client)
                 return;

--- a/ProceduralRoads/Src/Roads/RoadClearAreaManager.cs
+++ b/ProceduralRoads/Src/Roads/RoadClearAreaManager.cs
@@ -8,8 +8,8 @@ namespace ProceduralRoads;
 /// </summary>
 public static class RoadClearAreaManager
 {
-    private static readonly Dictionary<Vector2i, List<ZoneSystem.ClearArea>> s_roadClearAreasCache = 
-        new Dictionary<Vector2i, List<ZoneSystem.ClearArea>>();
+    private static readonly Dictionary<Vector2s, List<ZoneSystem.ClearArea>> s_roadClearAreasCache =
+        new Dictionary<Vector2s, List<ZoneSystem.ClearArea>>();
 
     public static void ClearCache()
     {
@@ -19,7 +19,7 @@ public static class RoadClearAreaManager
     /// <summary>
     /// Gets or creates road clear areas for a zone. Used to prevent vegetation spawning on roads.
     /// </summary>
-    public static List<ZoneSystem.ClearArea> GetOrCreateClearAreas(Vector2i zoneID)
+    public static List<ZoneSystem.ClearArea> GetOrCreateClearAreas(Vector2s zoneID)
     {
         if (!s_roadClearAreasCache.TryGetValue(zoneID, out List<ZoneSystem.ClearArea> roadClearAreas))
         {
@@ -30,7 +30,7 @@ public static class RoadClearAreaManager
         return roadClearAreas;
     }
 
-    private static List<ZoneSystem.ClearArea> CreateRoadClearAreas(Vector2i zoneID)
+    private static List<ZoneSystem.ClearArea> CreateRoadClearAreas(Vector2s zoneID)
     {
         List<ZoneSystem.ClearArea> clearAreas = new List<ZoneSystem.ClearArea>();
         List<RoadSpatialGrid.RoadPoint> roadPoints = RoadSpatialGrid.GetRoadPointsInZone(zoneID);

--- a/ProceduralRoads/Src/Roads/RoadSpatialGrid.cs
+++ b/ProceduralRoads/Src/Roads/RoadSpatialGrid.cs
@@ -490,7 +490,7 @@ public static class RoadSpatialGrid
         return t * t * (3f - 2f * t);
     }
 
-    public static List<RoadPoint> GetRoadPointsInZone(Vector2i zoneID)
+    public static List<RoadPoint> GetRoadPointsInZone(Vector2s zoneID)
     {
         List<RoadPoint> result = new List<RoadPoint>();
         
@@ -597,7 +597,7 @@ public static class RoadSpatialGrid
     /// Serialize road points for a specific zone to a byte array for ZDO storage.
     /// Uses the same logic as GetRoadPointsInZone to capture all affecting points.
     /// </summary>
-    public static byte[]? SerializeZoneRoadPoints(Vector2i zoneID)
+    public static byte[]? SerializeZoneRoadPoints(Vector2s zoneID)
     {
         var points = GetRoadPointsInZone(zoneID);
         
@@ -623,7 +623,7 @@ public static class RoadSpatialGrid
     /// Deserialize road points from a byte array and add them to the grid.
     /// Points are added to grid cells based on their actual position.
     /// </summary>
-    public static void DeserializeZoneRoadPoints(Vector2i zoneID, byte[] data)
+    public static void DeserializeZoneRoadPoints(Vector2s zoneID, byte[] data)
     {
         if (data == null || data.Length == 0)
             return;

--- a/ProceduralRoads/Src/Roads/RoadTerrainModifier.cs
+++ b/ProceduralRoads/Src/Roads/RoadTerrainModifier.cs
@@ -18,7 +18,7 @@ public static class RoadTerrainModifier
     /// <summary>
     /// Apply terrain mods for road points in a zone.
     /// </summary>
-    public static void ApplyRoadTerrainMods(Vector2i zoneID, List<RoadSpatialGrid.RoadPoint> roadPoints)
+    public static void ApplyRoadTerrainMods(Vector2s zoneID, List<RoadSpatialGrid.RoadPoint> roadPoints)
     {
         TerrainContext? context = GetTerrainContext(zoneID);
         if (context == null)
@@ -33,7 +33,7 @@ public static class RoadTerrainModifier
     /// Public entry point for applying road terrain mods to a specific zone.
     /// Used by console commands to force-update loaded zones.
     /// </summary>
-    public static void ApplyRoadTerrainModsWithContext(Vector2i zoneID, List<RoadSpatialGrid.RoadPoint> roadPoints, 
+    public static void ApplyRoadTerrainModsWithContext(Vector2s zoneID, List<RoadSpatialGrid.RoadPoint> roadPoints,
         Heightmap heightmap, TerrainComp terrainComp)
     {
         if (roadPoints == null || roadPoints.Count == 0)
@@ -69,7 +69,7 @@ public static class RoadTerrainModifier
         public float VertexSpacing;
     }
 
-    private static TerrainContext? GetTerrainContext(Vector2i zoneID)
+    private static TerrainContext? GetTerrainContext(Vector2s zoneID)
     {
         Heightmap heightmap = Heightmap.FindHeightmap(ZoneSystem.GetZonePos(zoneID));
         TerrainComp? terrainComp = heightmap?.GetAndCreateTerrainCompiler();
@@ -96,7 +96,7 @@ public static class RoadTerrainModifier
         public HashSet<Vector2i> PaintedCells;
     }
 
-    private static ModificationStats ModifyVertexHeights(Vector2i zoneID, List<RoadSpatialGrid.RoadPoint> roadPoints, TerrainContext context)
+    private static ModificationStats ModifyVertexHeights(Vector2s zoneID, List<RoadSpatialGrid.RoadPoint> roadPoints, TerrainContext context)
     {
         ModificationStats stats = new ModificationStats { PaintedCells = new HashSet<Vector2i>() };
 
@@ -248,7 +248,7 @@ public static class RoadTerrainModifier
         }
     }
 
-    private static void FinalizeTerrainMods(Vector2i zoneID, int roadPointCount, ModificationStats stats, TerrainContext context)
+    private static void FinalizeTerrainMods(Vector2s zoneID, int roadPointCount, ModificationStats stats, TerrainContext context)
     {
         int paintOps = stats.PaintedCells.Count;
         
@@ -266,7 +266,7 @@ public static class RoadTerrainModifier
         }
     }
 
-    private static void LogCoordinateDebug(Vector2i zoneID, List<RoadSpatialGrid.RoadPoint> roadPoints, TerrainContext context)
+    private static void LogCoordinateDebug(Vector2s zoneID, List<RoadSpatialGrid.RoadPoint> roadPoints, TerrainContext context)
     {
         if (s_coordLogCount >= RoadConstants.MaxCoordDebugLogs)
             return;

--- a/ProceduralRoads/Src/Utils/ConsoleCommands.cs
+++ b/ProceduralRoads/Src/Utils/ConsoleCommands.cs
@@ -299,7 +299,7 @@ public static class ConsoleCommands
         float searchRadius = 15f; // Search within 15m
 
         // Get zone info
-        Vector2i zoneID = ZoneSystem.GetZone(playerPos);
+        Vector2s zoneID = ZoneSystem.GetZone(playerPos);
         
         args.Context.AddString($"=== Road Debug at ({playerPos.x:F1}, {playerPos.z:F1}) ===");
         args.Context.AddString($"Zone: {zoneID}, Player altitude: {playerPos.y:F1}m");
@@ -467,7 +467,7 @@ public static class ConsoleCommands
                 if (heightmap == null) continue;
 
                 Vector3 hmPos = heightmap.transform.position;
-                Vector2i zoneID = ZoneSystem.GetZone(hmPos);
+                Vector2s zoneID = ZoneSystem.GetZone(hmPos);
 
                 var roadPoints = RoadSpatialGrid.GetRoadPointsInZone(zoneID);
                 if (roadPoints.Count == 0) continue;
@@ -502,7 +502,7 @@ public static class ConsoleCommands
         }
 
         Vector3 playerPos = player.transform.position;
-        Vector2i zoneID = ZoneSystem.GetZone(playerPos);
+        Vector2s zoneID = ZoneSystem.GetZone(playerPos);
 
         var roadPoints = RoadSpatialGrid.GetRoadPointsInZone(zoneID);
         if (roadPoints.Count == 0)
@@ -622,7 +622,7 @@ public static class ConsoleCommands
 
         Vector3 playerPos = player.transform.position;
         Vector2 playerPos2D = new Vector2(playerPos.x, playerPos.z);
-        Vector2i zoneID = ZoneSystem.GetZone(playerPos);
+        Vector2s zoneID = ZoneSystem.GetZone(playerPos);
 
         // Get road points from current and adjacent zones
         List<RoadSpatialGrid.RoadPoint> nearbyPoints = new List<RoadSpatialGrid.RoadPoint>();
@@ -630,7 +630,7 @@ public static class ConsoleCommands
         {
             for (int dz = -1; dz <= 1; dz++)
             {
-                Vector2i checkZone = new Vector2i(zoneID.x + dx, zoneID.y + dz);
+                Vector2s checkZone = new Vector2s((int)zoneID.x + dx, (int)zoneID.y + dz);
                 var zonePoints = RoadSpatialGrid.GetRoadPointsInZone(checkZone);
                 foreach (var rp in zonePoints)
                 {


### PR DESCRIPTION
## Summary
- Update ZoneSystem patch signatures from Vector2i to Vector2s for Valheim PTB.
- Carry Vector2s through road terrain and clear-area calls that interact with Valheim zones.
- Keep internal road grid and painted-cell coordinates as Vector2i where they are mod-owned grid values.

## Validation
- Built against the PTB server assembly mirror:
  dotnet build ProceduralRoads.sln /p:VALHEIM_INSTALL=/Users/benjmarston/Develop/valheim-ptb-server /p:BEPINEX_PATH="/Users/benjmarston/Library/Application Support/Steam/steamapps/common/Valheim/BepInEx"
- Deployed ProceduralRoads.dll to Hetzner praetoris PTB test server.
- Confirmed deployed DLL SHA256: e5b864914f2d365db0c2417430341e275a696f78b65ba9f9aa528122cfb2ebbf.
- Restarted test server through mmcli-agent with 0 players online.
- BepInEx logs show ProceduralRoads 1.4.3 loading; no ProceduralRoads-specific errors found.

## Notes
- Default local build against the current live Valheim assemblies is expected to fail because this branch targets the PTB ZoneSystem API.
- Dedicated-server validation passed; visual terrain/road behavior still needs client-side PTB testing.