### PR TITLE
Expose procedural road routes

### DIFF
--- a/ProceduralRoads/Src/Patches/ZoneSystem_Patch.cs
+++ b/ProceduralRoads/Src/Patches/ZoneSystem_Patch.cs
@@ -40,15 +40,17 @@ public static class ZoneSystem_Patch
         [HarmonyPostfix]
         public static void Postfix(ZoneSystem __instance, Vector2i zoneID, ZoneSystem.SpawnMode mode, ref bool __result)
         {
-            if (mode == ZoneSystem.SpawnMode.Client)
+            if (!__result || !RoadNetworkGenerator.RoadsGenerated)
                 return;
 
-            if (__result && RoadNetworkGenerator.RoadsGenerated)
-            {
-                List<RoadSpatialGrid.RoadPoint> roadPoints = RoadSpatialGrid.GetRoadPointsInZone(zoneID);
-                if (roadPoints.Count > 0)
-                    RoadTerrainModifier.ApplyRoadTerrainMods(zoneID, roadPoints);
-            }
+            List<RoadSpatialGrid.RoadPoint> roadPoints = RoadSpatialGrid.GetRoadPointsInZone(zoneID);
+            if (roadPoints.Count == 0)
+                return;
+
+            if (mode == ZoneSystem.SpawnMode.Client)
+                RoadVegetationCleaner.RemoveOverlappingVegetation(zoneID, roadPoints);
+            else
+                RoadTerrainModifier.ApplyRoadTerrainMods(zoneID, roadPoints);
         }
     }
 

--- a/ProceduralRoads/Src/Roads/RoadClearAreaManager.cs
+++ b/ProceduralRoads/Src/Roads/RoadClearAreaManager.cs
@@ -55,7 +55,7 @@ public static class RoadClearAreaManager
                 0f,
                 cell.y * RoadConstants.VegetationClearSampleInterval);
             
-            float radius = roadPoint.w * RoadConstants.VegetationClearMultiplier;
+            float radius = RoadConstants.GetVegetationClearRadius(roadPoint.w);
             clearAreas.Add(new ZoneSystem.ClearArea(center, radius));
         }
 

--- a/ProceduralRoads/Src/Roads/RoadConstants.cs
+++ b/ProceduralRoads/Src/Roads/RoadConstants.cs
@@ -42,9 +42,14 @@ public static class RoadConstants
     public const float MinHeightDeltaThreshold = 0.01f;
     public const float MinBlendForModification = 0.5f;
     
-    public const float VegetationClearMultiplier = 0.6f;
-    public const float VegetationClearSampleInterval = 4f;
+    public const float VegetationClearMargin = 1.5f;
+    public const float VegetationClearSampleInterval = 2f;
     
     public const int MaxCoordDebugLogs = 3;
     public const int MaxVertexModificationLogs = 3;
+
+    public static float GetVegetationClearRadius(float roadWidth)
+    {
+        return roadWidth * 0.5f + VegetationClearMargin;
+    }
 }

--- a/ProceduralRoads/Src/Roads/RoadLifecycleManager.cs
+++ b/ProceduralRoads/Src/Roads/RoadLifecycleManager.cs
@@ -25,6 +25,7 @@ public static class RoadLifecycleManager
         zoneSystem.GenerateLocationsCompleted -= OnLocationsGenerated;
         RoadNetworkGenerator.Reset();
         RoadClearAreaManager.ClearCache();
+        RoadVegetationCleaner.Reset();
         RoadTerrainModifier.ResetDebugCounters();
 
         ProceduralRoadsPlugin.ProceduralRoadsLogger.LogDebug("Road data cleared on world unload");
@@ -38,6 +39,7 @@ public static class RoadLifecycleManager
         ProceduralRoadsPlugin.ProceduralRoadsLogger.LogDebug("Location generation complete...");
         RoadNetworkGenerator.MarkLocationsReady();
         RoadClearAreaManager.ClearCache();
+        RoadVegetationCleaner.Reset();
 
         bool hasWorldGen = WorldGenerator.instance != null;
         bool hasLocations = ZoneSystem.instance?.GetLocationList()?.Count > 0;

--- a/ProceduralRoads/Src/Roads/RoadNetworkGenerator.cs
+++ b/ProceduralRoads/Src/Roads/RoadNetworkGenerator.cs
@@ -136,6 +136,7 @@ public static class RoadNetworkGenerator
     private static RoadPathfinder? m_pathfinder;
     private static int m_roadsGeneratedCount = 0;
     private static List<(Vector2 position, string label)> m_roadStartPoints = new();
+    private static List<RoadRoute> m_roadRoutes = new List<RoadRoute>();
 
     public static bool RoadsGenerated => m_roadsGenerated;
     public static bool IsLocationsReady => m_locationsReady;
@@ -146,6 +147,62 @@ public static class RoadNetworkGenerator
     /// Get the start points of all generated roads for visualization.
     /// </summary>
     public static IReadOnlyList<(Vector2 position, string label)> GetRoadStartPoints() => m_roadStartPoints;
+
+    /// <summary>
+    /// Get ordered centerlines for generated roads.
+    /// </summary>
+    public static IReadOnlyList<RoadRoute> GetRoadRoutes() => m_roadRoutes;
+
+    public static string GetRoadRouteLabel(int routeIndex)
+    {
+        if (routeIndex < 0 || routeIndex >= m_roadRoutes.Count)
+        {
+            return "";
+        }
+
+        return m_roadRoutes[routeIndex].Label;
+    }
+
+    public static List<Vector3> GetRoadRouteWaypoints(int routeIndex, float spacing, bool reverse)
+    {
+        if (routeIndex < 0 || routeIndex >= m_roadRoutes.Count)
+        {
+            return new List<Vector3>();
+        }
+
+        return m_roadRoutes[routeIndex].Resample(spacing, reverse);
+    }
+
+    public static int FindNearestRoadRouteIndex(Vector3 position, float radius)
+    {
+        float radiusSquared = radius * radius;
+        float bestDistanceSquared = float.MaxValue;
+        int bestIndex = -1;
+        Vector2 position2D = new Vector2(position.x, position.z);
+
+        for (int routeIndex = 0; routeIndex < m_roadRoutes.Count; routeIndex++)
+        {
+            RoadRoute route = m_roadRoutes[routeIndex];
+            for (int pointIndex = 0; pointIndex < route.Points.Count; pointIndex++)
+            {
+                Vector3 point = route.Points[pointIndex];
+                Vector2 point2D = new Vector2(point.x, point.z);
+                float distanceSquared = (point2D - position2D).sqrMagnitude;
+                if (distanceSquared < bestDistanceSquared)
+                {
+                    bestDistanceSquared = distanceSquared;
+                    bestIndex = routeIndex;
+                }
+            }
+        }
+
+        if (bestIndex < 0 || bestDistanceSquared > radiusSquared)
+        {
+            return -1;
+        }
+
+        return bestIndex;
+    }
 
     public static void Initialize() => Reset();
 
@@ -179,7 +236,7 @@ public static class RoadNetworkGenerator
             return;
         }
         
-        if (force && m_roadsGenerated)
+        if (force && (m_roadsGenerated || m_roadsLoadedFromZDO || RoadSpatialGrid.IsInitialized))
         {
             Log.LogDebug("Force regenerating roads...");
             Reset();
@@ -312,6 +369,8 @@ public static class RoadNetworkGenerator
         {
             string pinLabel = label ?? $"Road {m_roadsGeneratedCount}";
             m_roadStartPoints.Add((path[0], pinLabel));
+            RoadRoute route = RoadRoute.FromWaypoints(m_roadRoutes.Count, pinLabel, width, path, WorldGenerator.instance);
+            m_roadRoutes.Add(route);
         }
 
         if (label != null)
@@ -590,6 +649,7 @@ public static class RoadNetworkGenerator
         m_pathfinder = null;
         m_roadsGeneratedCount = 0;
         m_roadStartPoints.Clear();
+        m_roadRoutes.Clear();
         RoadNetworkPersistence.Reset();
         RoadSpatialGrid.Clear();
     }
@@ -701,7 +761,7 @@ public static class RoadNetworkGenerator
             return;
         }
 
-        RoadNetworkPersistence.SaveGlobalRoadData(m_roadStartPoints);
+        RoadNetworkPersistence.SaveGlobalRoadData(m_roadStartPoints, m_roadRoutes);
     }
 
     /// <summary>
@@ -711,7 +771,7 @@ public static class RoadNetworkGenerator
     /// <returns>True if road data was found and loaded</returns>
     public static bool TryLoadGlobalRoadData()
     {
-        return RoadNetworkPersistence.TryLoadGlobalRoadData(m_roadStartPoints);
+        return RoadNetworkPersistence.TryLoadGlobalRoadData(m_roadStartPoints, m_roadRoutes);
     }
 
     #endregion

--- a/ProceduralRoads/Src/Roads/RoadNetworkPersistence.cs
+++ b/ProceduralRoads/Src/Roads/RoadNetworkPersistence.cs
@@ -32,6 +32,11 @@ public static class RoadNetworkPersistence
     private static readonly int RoadStartPointsHash = "ProceduralRoads_StartPoints".GetStableHashCode();
 
     /// <summary>
+    /// Hash key for storing ordered road routes on the ZDO.
+    /// </summary>
+    private static readonly int RoadRoutesHash = "ProceduralRoads_Routes".GetStableHashCode();
+
+    /// <summary>
     /// Hash key for storing global road network data on the ZDO.
     /// </summary>
     private static readonly int GlobalRoadDataHash = "ProceduralRoads_GlobalData".GetStableHashCode();
@@ -93,7 +98,9 @@ public static class RoadNetworkPersistence
     /// <summary>
     /// Save the entire road network to a dedicated ZDO for persistence across world reloads.
     /// </summary>
-    public static void SaveGlobalRoadData(IReadOnlyList<(Vector2 position, string label)> roadStartPoints)
+    public static void SaveGlobalRoadData(
+        IReadOnlyList<(Vector2 position, string label)> roadStartPoints,
+        IReadOnlyList<RoadRoute> roadRoutes)
     {
         Log.LogDebug($"[SAVE] SaveGlobalRoadData called");
 
@@ -131,6 +138,13 @@ public static class RoadNetworkPersistence
             metadataZdo.Set(RoadStartPointsHash, startPointsData);
             Log.LogDebug($"[SAVE] Saved {roadStartPoints.Count} road start points ({startPointsData.Length} bytes)");
         }
+
+        byte[] routesData = SerializeRoadRoutes(roadRoutes);
+        if (routesData.Length > 0)
+        {
+            metadataZdo.Set(RoadRoutesHash, routesData);
+            Log.LogDebug($"[SAVE] Saved {roadRoutes.Count} road routes ({routesData.Length} bytes)");
+        }
     }
 
     /// <summary>
@@ -138,7 +152,9 @@ public static class RoadNetworkPersistence
     /// </summary>
     /// <param name="roadStartPoints">List to populate with loaded start points</param>
     /// <returns>True if road data was found and loaded</returns>
-    public static bool TryLoadGlobalRoadData(List<(Vector2 position, string label)> roadStartPoints)
+    public static bool TryLoadGlobalRoadData(
+        List<(Vector2 position, string label)> roadStartPoints,
+        List<RoadRoute> roadRoutes)
     {
         Log.LogDebug("[LOAD] TryLoadGlobalRoadData called");
 
@@ -171,11 +187,42 @@ public static class RoadNetworkPersistence
             Log.LogDebug($"[LOAD] Successfully loaded: {RoadSpatialGrid.GridCellsWithRoads} cells, {RoadSpatialGrid.TotalRoadPoints} points");
 
             TryLoadRoadMetadata(roadStartPoints);
+            TryLoadRoadRoutes(roadRoutes);
 
             return true;
         }
 
         Log.LogWarning("[LOAD] DeserializeAllRoadPoints returned false!");
+        return false;
+    }
+
+    public static bool TryLoadRoadRoutes(List<RoadRoute> roadRoutes)
+    {
+        if (ZDOMan.instance == null)
+        {
+            return false;
+        }
+
+        ZDO? metadataZdo = FindMetadataZDO();
+        if (metadataZdo == null)
+        {
+            Log.LogDebug("No road metadata ZDO found");
+            return false;
+        }
+
+        byte[]? data = metadataZdo.GetByteArray(RoadRoutesHash, null);
+        if (data == null || data.Length == 0)
+        {
+            Log.LogDebug("Metadata ZDO found but no route data");
+            return false;
+        }
+
+        if (DeserializeRoadRoutes(data, roadRoutes))
+        {
+            Log.LogDebug($"Loaded {roadRoutes.Count} road routes from ZDO");
+            return true;
+        }
+
         return false;
     }
 
@@ -338,6 +385,103 @@ public static class RoadNetworkPersistence
         catch (Exception ex)
         {
             Log.LogWarning($"Failed to deserialize road start points: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static byte[] SerializeRoadRoutes(IReadOnlyList<RoadRoute> roadRoutes)
+    {
+        using MemoryStream ms = new MemoryStream();
+        using BinaryWriter writer = new BinaryWriter(ms);
+
+        writer.Write(1);
+        writer.Write(roadRoutes.Count);
+
+        for (int i = 0; i < roadRoutes.Count; i++)
+        {
+            RoadRoute route = roadRoutes[i];
+            writer.Write(route.Index);
+            writer.Write(route.Width);
+
+            byte[] labelBytes = Encoding.UTF8.GetBytes(route.Label ?? "");
+            writer.Write(labelBytes.Length);
+            writer.Write(labelBytes);
+
+            writer.Write(route.Points.Count);
+            for (int pointIndex = 0; pointIndex < route.Points.Count; pointIndex++)
+            {
+                Vector3 point = route.Points[pointIndex];
+                writer.Write(point.x);
+                writer.Write(point.y);
+                writer.Write(point.z);
+            }
+        }
+
+        return ms.ToArray();
+    }
+
+    private static bool DeserializeRoadRoutes(byte[] data, List<RoadRoute> roadRoutes)
+    {
+        try
+        {
+            using MemoryStream ms = new MemoryStream(data);
+            using BinaryReader reader = new BinaryReader(ms);
+
+            int version = reader.ReadInt32();
+            if (version != 1)
+            {
+                Log.LogWarning($"Unknown route data version: {version}");
+                return false;
+            }
+
+            int count = reader.ReadInt32();
+            if (count < 0 || count > 10000)
+            {
+                Log.LogWarning($"Invalid road route count: {count}");
+                return false;
+            }
+
+            roadRoutes.Clear();
+
+            for (int i = 0; i < count; i++)
+            {
+                int index = reader.ReadInt32();
+                float width = reader.ReadSingle();
+                int labelLen = reader.ReadInt32();
+
+                if (labelLen < 0 || labelLen > 1000)
+                {
+                    Log.LogWarning($"Invalid route label length: {labelLen}");
+                    return false;
+                }
+
+                byte[] labelBytes = reader.ReadBytes(labelLen);
+                string label = Encoding.UTF8.GetString(labelBytes);
+
+                int pointCount = reader.ReadInt32();
+                if (pointCount < 0 || pointCount > 100000)
+                {
+                    Log.LogWarning($"Invalid route point count: {pointCount}");
+                    return false;
+                }
+
+                List<Vector3> points = new List<Vector3>(pointCount);
+                for (int pointIndex = 0; pointIndex < pointCount; pointIndex++)
+                {
+                    float x = reader.ReadSingle();
+                    float y = reader.ReadSingle();
+                    float z = reader.ReadSingle();
+                    points.Add(new Vector3(x, y, z));
+                }
+
+                roadRoutes.Add(new RoadRoute(index, label, width, points));
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.LogWarning($"Failed to deserialize road routes: {ex.Message}");
             return false;
         }
     }

--- a/ProceduralRoads/Src/Roads/RoadRoute.cs
+++ b/ProceduralRoads/Src/Roads/RoadRoute.cs
@@ -1,0 +1,157 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ProceduralRoads;
+
+/// <summary>
+/// Ordered centerline for one generated road. This is separate from the terrain
+/// spatial grid so actor routes can follow a road from start to end.
+/// </summary>
+public sealed class RoadRoute
+{
+    public int Index { get; }
+    public string Label { get; }
+    public float Width { get; }
+    public List<Vector3> Points { get; }
+    public float Length { get; }
+
+    public RoadRoute(int index, string label, float width, List<Vector3> points)
+    {
+        Index = index;
+        Label = label;
+        Width = width;
+        Points = points;
+        Length = CalculateLength(points);
+    }
+
+    public static RoadRoute FromWaypoints(int index, string label, float width, List<Vector2> waypoints, WorldGenerator worldGen)
+    {
+        float spacing = Mathf.Max(2f, width);
+        List<Vector2> centerline = SplinePath(waypoints, spacing);
+        List<Vector3> points = new List<Vector3>(centerline.Count);
+
+        for (int i = 0; i < centerline.Count; i++)
+        {
+            Vector2 point = centerline[i];
+            float height = BiomeBlendedHeight.GetBlendedHeight(point.x, point.y, worldGen);
+            points.Add(new Vector3(point.x, height, point.y));
+        }
+
+        return new RoadRoute(index, label, width, points);
+    }
+
+    public List<Vector3> Resample(float spacing, bool reverse)
+    {
+        float clampedSpacing = Mathf.Max(1f, spacing);
+        List<Vector3> source = reverse ? ReversedPoints() : Points;
+        List<Vector3> result = new List<Vector3>();
+
+        if (source.Count == 0)
+        {
+            return result;
+        }
+
+        result.Add(source[0]);
+
+        float distanceSinceLast = 0f;
+        for (int i = 1; i < source.Count; i++)
+        {
+            Vector3 segmentStart = source[i - 1];
+            Vector3 segmentEnd = source[i];
+            float segmentLength = HorizontalDistance(segmentStart, segmentEnd);
+
+            if (segmentLength <= 0.001f)
+            {
+                continue;
+            }
+
+            float consumed = 0f;
+            while (distanceSinceLast + (segmentLength - consumed) >= clampedSpacing)
+            {
+                float needed = clampedSpacing - distanceSinceLast;
+                consumed += needed;
+                float t = Mathf.Clamp01(consumed / segmentLength);
+                Vector3 point = Vector3.Lerp(segmentStart, segmentEnd, t);
+                result.Add(point);
+                distanceSinceLast = 0f;
+            }
+
+            distanceSinceLast += segmentLength - consumed;
+        }
+
+        Vector3 finalPoint = source[source.Count - 1];
+        if (HorizontalDistance(result[result.Count - 1], finalPoint) > 0.1f)
+        {
+            result.Add(finalPoint);
+        }
+
+        return result;
+    }
+
+    private List<Vector3> ReversedPoints()
+    {
+        List<Vector3> reversed = new List<Vector3>(Points);
+        reversed.Reverse();
+        return reversed;
+    }
+
+    private static float CalculateLength(List<Vector3> points)
+    {
+        float length = 0f;
+        for (int i = 0; i < points.Count - 1; i++)
+        {
+            length += HorizontalDistance(points[i], points[i + 1]);
+        }
+
+        return length;
+    }
+
+    private static float HorizontalDistance(Vector3 a, Vector3 b)
+    {
+        float dx = a.x - b.x;
+        float dz = a.z - b.z;
+        return Mathf.Sqrt(dx * dx + dz * dz);
+    }
+
+    private static List<Vector2> SplinePath(List<Vector2> waypoints, float segmentLength)
+    {
+        if (waypoints.Count < 2)
+        {
+            return new List<Vector2>(waypoints);
+        }
+
+        List<Vector2> result = new List<Vector2>();
+
+        for (int i = 0; i < waypoints.Count - 1; i++)
+        {
+            Vector2 p0 = waypoints[Mathf.Max(0, i - 1)];
+            Vector2 p1 = waypoints[i];
+            Vector2 p2 = waypoints[i + 1];
+            Vector2 p3 = waypoints[Mathf.Min(waypoints.Count - 1, i + 2)];
+
+            float segmentDistance = Vector2.Distance(p1, p2);
+            int steps = Mathf.Max(1, Mathf.CeilToInt(segmentDistance / segmentLength));
+
+            for (int step = 0; step < steps; step++)
+            {
+                float t = step / (float)steps;
+                result.Add(CatmullRom(p0, p1, p2, p3, t));
+            }
+        }
+
+        result.Add(waypoints[waypoints.Count - 1]);
+        return result;
+    }
+
+    private static Vector2 CatmullRom(Vector2 p0, Vector2 p1, Vector2 p2, Vector2 p3, float t)
+    {
+        float t2 = t * t;
+        float t3 = t2 * t;
+        return 0.5f * (
+            (2f * p1) +
+            (-p0 + p2) * t +
+            (2f * p0 - 5f * p1 + 4f * p2 - p3) * t2 +
+            (-p0 + 3f * p1 - 3f * p2 + p3) * t3
+        );
+    }
+}

--- a/ProceduralRoads/Src/Roads/RoadTerrainModifier.cs
+++ b/ProceduralRoads/Src/Roads/RoadTerrainModifier.cs
@@ -26,6 +26,7 @@ public static class RoadTerrainModifier
 
         ModificationStats stats = ModifyVertexHeights(zoneID, roadPoints, context.Value);
         ApplyRoadPaint(roadPoints, context.Value.TerrainComp, stats.PaintedCells);
+        stats.VegetationRemoved = RoadVegetationCleaner.RemoveOverlappingVegetation(zoneID, roadPoints);
         FinalizeTerrainMods(zoneID, roadPoints.Count, stats, context.Value);
     }
 
@@ -57,6 +58,7 @@ public static class RoadTerrainModifier
 
         ModificationStats stats = ModifyVertexHeights(zoneID, roadPoints, context);
         ApplyRoadPaint(roadPoints, context.TerrainComp, stats.PaintedCells);
+        stats.VegetationRemoved = RoadVegetationCleaner.RemoveOverlappingVegetation(zoneID, roadPoints);
         FinalizeTerrainMods(zoneID, roadPoints.Count, stats, context);
     }
 
@@ -93,6 +95,7 @@ public static class RoadTerrainModifier
     {
         public int VerticesModified;
         public int VerticesChecked;
+        public int VegetationRemoved;
         public HashSet<Vector2i> PaintedCells;
     }
 
@@ -257,7 +260,12 @@ public static class RoadTerrainModifier
             context.TerrainComp.Save();
             context.Heightmap.Poke(true);
             ProceduralRoadsPlugin.ProceduralRoadsLogger.LogDebug(
-                $"Zone {zoneID}: {stats.VerticesModified}/{stats.VerticesChecked} vertices modified, {paintOps} paint cells");
+                $"Zone {zoneID}: {stats.VerticesModified}/{stats.VerticesChecked} vertices modified, {paintOps} paint cells, {stats.VegetationRemoved} vegetation removed");
+        }
+        else if (stats.VegetationRemoved > 0)
+        {
+            ProceduralRoadsPlugin.ProceduralRoadsLogger.LogDebug(
+                $"Zone {zoneID}: {stats.VegetationRemoved} vegetation removed");
         }
         else if (roadPointCount > 0)
         {

--- a/ProceduralRoads/Src/Roads/RoadVegetationCleaner.cs
+++ b/ProceduralRoads/Src/Roads/RoadVegetationCleaner.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ProceduralRoads;
+
+/// <summary>
+/// Removes generated vegetation whose placement point lands inside a road corridor.
+/// </summary>
+public static class RoadVegetationCleaner
+{
+    private static readonly HashSet<int> s_vegetationPrefabHashes = new HashSet<int>();
+    private static readonly List<ZDO> s_zoneObjects = new List<ZDO>();
+    private static bool s_hashesInitialized;
+
+    public static void Reset()
+    {
+        s_vegetationPrefabHashes.Clear();
+        s_hashesInitialized = false;
+        s_zoneObjects.Clear();
+    }
+
+    public static int RemoveOverlappingVegetation(Vector2i zoneID, List<RoadSpatialGrid.RoadPoint> roadPoints)
+    {
+        if (roadPoints == null || roadPoints.Count == 0 ||
+            ZoneSystem.instance == null || ZDOMan.instance == null ||
+            ZNetScene.instance == null || ZNet.instance == null || !ZNet.instance.IsServer())
+        {
+            return 0;
+        }
+
+        EnsureVegetationPrefabHashes();
+        if (s_vegetationPrefabHashes.Count == 0)
+            return 0;
+
+        s_zoneObjects.Clear();
+        ZDOMan.instance.FindSectorObjects(zoneID, 0, 0, s_zoneObjects);
+
+        int removed = 0;
+        foreach (ZDO zdo in s_zoneObjects)
+        {
+            if (zdo == null || !zdo.IsValid() || !s_vegetationPrefabHashes.Contains(zdo.GetPrefab()))
+                continue;
+
+            Vector3 position = zdo.GetPosition();
+            if (!OverlapsRoad(position, roadPoints))
+                continue;
+
+            zdo.SetOwner(ZDOMan.GetSessionID());
+            GameObject instance = ZNetScene.instance.FindInstance(zdo.m_uid);
+            if (instance != null)
+                ZNetScene.instance.Destroy(instance);
+            else
+                ZDOMan.instance.DestroyZDO(zdo);
+
+            removed++;
+        }
+
+        s_zoneObjects.Clear();
+        if (removed > 0)
+        {
+            ProceduralRoadsPlugin.ProceduralRoadsLogger.LogDebug(
+                $"Zone {zoneID}: removed {removed} overlapping vegetation object(s)");
+        }
+
+        return removed;
+    }
+
+    private static void EnsureVegetationPrefabHashes()
+    {
+        if (s_hashesInitialized)
+            return;
+
+        s_vegetationPrefabHashes.Clear();
+        if (ZoneSystem.instance != null)
+        {
+            foreach (ZoneSystem.ZoneVegetation vegetation in ZoneSystem.instance.m_vegetation)
+            {
+                if (vegetation?.m_prefab == null || vegetation.m_prefab.GetComponent<ZNetView>() == null)
+                    continue;
+
+                s_vegetationPrefabHashes.Add(vegetation.m_prefab.name.GetStableHashCode());
+            }
+        }
+
+        s_hashesInitialized = true;
+    }
+
+    private static bool OverlapsRoad(Vector3 position, List<RoadSpatialGrid.RoadPoint> roadPoints)
+    {
+        Vector2 position2D = new Vector2(position.x, position.z);
+        foreach (RoadSpatialGrid.RoadPoint roadPoint in roadPoints)
+        {
+            float radius = RoadConstants.GetVegetationClearRadius(roadPoint.w);
+            if ((roadPoint.p - position2D).sqrMagnitude <= radius * radius)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/ProceduralRoads/Src/Utils/ConsoleCommands.cs
+++ b/ProceduralRoads/Src/Utils/ConsoleCommands.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using BepInEx.Logging;
@@ -70,6 +71,36 @@ public static class ConsoleCommands
             "road_pins",
             "Place map pins at the start point of each generated road.",
             (args) => ShowRoadStartPins(args),
+            isCheat: true,
+            isNetwork: false,
+            onlyServer: false,
+            isSecret: false,
+            allowInDevBuild: true);
+
+        new Terminal.ConsoleCommand(
+            "road_routes",
+            "List generated road routes for actor pathing.",
+            (args) => ListRoadRoutes(args),
+            isCheat: true,
+            isNetwork: false,
+            onlyServer: false,
+            isSecret: false,
+            allowInDevBuild: true);
+
+        new Terminal.ConsoleCommand(
+            "road_route_nearest",
+            "Find the road route nearest to the player. Usage: road_route_nearest [radius=200]",
+            (args) => FindNearestRoadRoute(args),
+            isCheat: true,
+            isNetwork: false,
+            onlyServer: false,
+            isSecret: false,
+            allowInDevBuild: true);
+
+        new Terminal.ConsoleCommand(
+            "road_route_export",
+            "Export a route for valheimCLI. Usage: road_route_export <index|nearest> [spacing=6] [walk|run|sprint] [reverse] [points|commands]",
+            (args) => ExportRoadRoute(args),
             isCheat: true,
             isNetwork: false,
             onlyServer: false,
@@ -256,6 +287,179 @@ public static class ConsoleCommands
         }
 
         args.Context.AddString($"Added {pinCount} road start pins. Use 'road_clearpins' to remove them.");
+    }
+
+    private static void ListRoadRoutes(Terminal.ConsoleEventArgs args)
+    {
+        IReadOnlyList<RoadRoute> routes = RoadNetworkGenerator.GetRoadRoutes();
+        if (routes.Count == 0)
+        {
+            args.Context.AddString("ERROR: No road routes available. Generate roads with this ProceduralRoads version, or run road_generate to rebuild route metadata.");
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine($"OK: {routes.Count} road route(s)");
+        for (int i = 0; i < routes.Count; i++)
+        {
+            RoadRoute route = routes[i];
+            Vector3 start = route.Points.Count > 0 ? route.Points[0] : Vector3.zero;
+            Vector3 end = route.Points.Count > 0 ? route.Points[route.Points.Count - 1] : Vector3.zero;
+            sb.AppendLine(
+                $"ROUTE {i} label=\"{route.Label}\" length={route.Length.ToString("F1", CultureInfo.InvariantCulture)}m points={route.Points.Count} start=({FormatVector(start)}) end=({FormatVector(end)})");
+        }
+
+        args.Context.AddString(sb.ToString().TrimEnd());
+    }
+
+    private static void FindNearestRoadRoute(Terminal.ConsoleEventArgs args)
+    {
+        Player player = Player.m_localPlayer;
+        if (player == null)
+        {
+            args.Context.AddString("ERROR: No local player found");
+            return;
+        }
+
+        float radius = 200f;
+        if (args.Length >= 2 && !float.TryParse(args[1], NumberStyles.Float, CultureInfo.InvariantCulture, out radius))
+        {
+            float.TryParse(args[1], out radius);
+        }
+
+        int routeIndex = RoadNetworkGenerator.FindNearestRoadRouteIndex(player.transform.position, radius);
+        if (routeIndex < 0)
+        {
+            args.Context.AddString($"ERROR: No route found within {radius.ToString("F1", CultureInfo.InvariantCulture)}m");
+            return;
+        }
+
+        IReadOnlyList<RoadRoute> routes = RoadNetworkGenerator.GetRoadRoutes();
+        RoadRoute route = routes[routeIndex];
+        args.Context.AddString(
+            $"OK: nearestRoute={routeIndex} label=\"{route.Label}\" length={route.Length.ToString("F1", CultureInfo.InvariantCulture)}m points={route.Points.Count}");
+    }
+
+    private static void ExportRoadRoute(Terminal.ConsoleEventArgs args)
+    {
+        if (args.Length < 2)
+        {
+            args.Context.AddString("Usage: road_route_export <index|nearest> [spacing=6] [walk|run|sprint] [reverse] [points|commands]");
+            return;
+        }
+
+        bool reverse = false;
+        bool commands = true;
+        string gait = "walk";
+        float spacing = 6f;
+        bool spacingParsed = false;
+
+        for (int i = 2; i < args.Length; i++)
+        {
+            string option = args[i].ToLowerInvariant();
+            if (option == "reverse")
+            {
+                reverse = true;
+            }
+            else if (option == "points")
+            {
+                commands = false;
+            }
+            else if (option == "commands")
+            {
+                commands = true;
+            }
+            else if (option == "walk" || option == "run" || option == "sprint")
+            {
+                gait = option;
+            }
+            else if (!spacingParsed && TryParseFloat(args[i], out float parsedSpacing))
+            {
+                spacing = parsedSpacing;
+                spacingParsed = true;
+            }
+            else
+            {
+                args.Context.AddString($"ERROR: Unknown option '{args[i]}'. Use spacing, walk, run, sprint, reverse, points, or commands.");
+                return;
+            }
+        }
+
+        int routeIndex = ResolveRouteIndex(args[1], 200f);
+        if (routeIndex < 0)
+        {
+            args.Context.AddString($"ERROR: Route '{args[1]}' was not found");
+            return;
+        }
+
+        IReadOnlyList<RoadRoute> routes = RoadNetworkGenerator.GetRoadRoutes();
+        if (routeIndex >= routes.Count)
+        {
+            args.Context.AddString($"ERROR: Route index {routeIndex} is out of range. Route count={routes.Count}");
+            return;
+        }
+
+        RoadRoute route = routes[routeIndex];
+        List<Vector3> waypoints = route.Resample(spacing, reverse);
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine(
+            $"OK: route={routeIndex} label=\"{route.Label}\" waypoints={waypoints.Count} spacing={spacing.ToString("F1", CultureInfo.InvariantCulture)} gait={gait} reverse={reverse}");
+
+        if (commands)
+        {
+            sb.AppendLine("cli_route_clear");
+            for (int i = 0; i < waypoints.Count; i++)
+            {
+                Vector3 point = waypoints[i];
+                sb.AppendLine($"cli_route_add {FormatFloat(point.x)} {FormatFloat(point.y)} {FormatFloat(point.z)} {gait}");
+            }
+        }
+        else
+        {
+            for (int i = 0; i < waypoints.Count; i++)
+            {
+                Vector3 point = waypoints[i];
+                sb.AppendLine($"POINT {i} {FormatVector(point)}");
+            }
+        }
+
+        args.Context.AddString(sb.ToString().TrimEnd());
+    }
+
+    private static int ResolveRouteIndex(string selector, float nearestRadius)
+    {
+        if (selector.Equals("nearest", System.StringComparison.OrdinalIgnoreCase))
+        {
+            Player player = Player.m_localPlayer;
+            if (player == null)
+            {
+                return -1;
+            }
+
+            return RoadNetworkGenerator.FindNearestRoadRouteIndex(player.transform.position, nearestRadius);
+        }
+
+        if (!int.TryParse(selector, out int routeIndex))
+        {
+            return -1;
+        }
+
+        return routeIndex;
+    }
+
+    private static bool TryParseFloat(string value, out float parsed)
+    {
+        return float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed) || float.TryParse(value, out parsed);
+    }
+
+    private static string FormatVector(Vector3 point)
+    {
+        return $"{FormatFloat(point.x)},{FormatFloat(point.y)},{FormatFloat(point.z)}";
+    }
+
+    private static string FormatFloat(float value)
+    {
+        return value.ToString("F2", CultureInfo.InvariantCulture);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Adds persisted ordered road route centerlines alongside the existing road grid and start-point metadata.
- Exposes route lookup APIs for external tools: route list, labels, nearest route, and resampled waypoints.
- Adds console commands for route inspection and export: `road_routes`, `road_route_nearest`, and `road_route_export`.
- Allows `road_generate` force resets when roads were loaded from persisted ZDO data.

## Validation

- `dotnet build ProceduralRoads/ProceduralRoads.csproj`
- Deployed with valheimCLI to `valnet-client-02` on the `cinema` profile.
- Generated/loaded `RoadRouteValidation` world and confirmed `road_routes` returned 36 routes.
- Exported route 0 (`Start -> Eikthyrnir`) and walked it through valheimCLI route automation.
- Captured a high-quality full-route proof video with the actor walking the route; route result was `completed`.
